### PR TITLE
Add support for deleting endpoints

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -15,6 +15,17 @@ from mlflow.utils.file_utils import TempDir, _copy_project
 
 DEFAULT_IMAGE_NAME = "mlflow-pyfunc"
 
+PREBUILT_IMAGE_URLS = {
+    "us-west-2": "XXXXXXX.dkr.ecr.us-west-2.amazonaws.com/mlflow-pyfunc",
+}
+
+def _get_prebuilt_image_url(region):
+    if region not in PREBUILT_IMAGE_URLS:
+        return None
+    return (PREBUILT_IMAGE_URLS[region] + ":{version}").format(version=mlflow.version.NEXT_VERSION)
+
+DEFAULT_BUCKET_NAME_PREFIX = "mlflow-sagemaker"
+
 _DOCKERFILE_TEMPLATE = """
 # Build an image that can serve pyfunc model in SageMaker
 FROM ubuntu:16.04
@@ -135,29 +146,47 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     os.system(cmd)
 
 
-def deploy(app_name, model_path, execution_role_arn, bucket, run_id=None,
-           image="mlflow_sage", region_name="us-west-2"):
+def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=None,
+           image=None, region_name="us-west-2"):
     """
-    Deploy model on Sagemaker.
+    Deploy model on SageMaker.
     Current active AWS account needs to have correct permissions setup.
 
     :param app_name: Name of the deployed app.
     :param path: Path to the model.
-                Either local if no run_id or MLflow-relative if run_id is specified)
-    :param execution_role_arn: Amazon execution role with sagemaker rights
-    :param bucket: S3 bucket where model artifacts are gonna be stored
+                 Either local if no run_id or MLflow-relative if run_id is specified)
+    :param execution_role_arn: Amazon execution role with sagemaker rights. defaults
+                               to the currently-assumed role.
+    :param bucket: S3 bucket where model artifacts will be stored. defaults to a
+                   SageMaker-compatible bucket name.
     :param run_id: MLflow run id.
-    :param image: name of the Docker image to be used.
-    :param region_name: Name of the AWS region to deploy to.
+    :param image: name of the Docker image to be used. if not specified, uses a 
+                  publicly-available pre-built image.
+    :param region_name: Name of the AWS region to deploy to. defaults to 
     """
+    image_url = _get_prebuilt_image_url(region)
+    if image or image_url is None:
+        ecr_client = boto3.client("ecr")
+        repository_conf = ecr_client.describe_repositories(
+            repositoryNames=[image])['repositories'][0]
+        image_url = repository_conf["repositoryUri"]
+
+    if not execution_role_arn:
+        execution_role_arn = _get_assumed_role_arn()
+
+    if not bucket:
+        eprint("No model data bucket specified, using the default bucket") 
+        bucket = _get_default_s3_bucket(region_name)
+
     prefix = model_path
     if run_id:
         model_path = _get_model_log_dir(model_path, run_id)
-        prefix = run_id + "/" + prefix
+        prefix = os.path.join(run_id, prefix)
     run_id = _check_compatible(model_path)
+
     model_s3_path = _upload_s3(local_model_path=model_path, bucket=bucket, prefix=prefix)
     _deploy(role=execution_role_arn,
-            image=image,
+            image_url=image_url,
             app_name=app_name,
             model_s3_path=model_s3_path,
             run_id=run_id,
@@ -205,6 +234,52 @@ def _check_compatible(path):
     return model.run_id if hasattr(model, "run_id") else None
 
 
+def _get_account_id():
+    sess = boto3.Session()
+    sts_client = sess.client("sts")
+    identity_info = sts_client.get_caller_identity()
+    account_id = identity_info["Account"]
+    return account_id 
+
+
+def _get_assumed_role_arn():
+    """
+    :return: ARN of the user's current IAM role 
+    """
+    sess = boto3.Session()
+    sts_client = sess.client("sts")
+    identity_info = sts_client.get_caller_identity()
+    sts_arn = identity_info["Arn"]
+    role_name = sts_arn.split("/")[1]
+    iam_client = sess.client("iam")
+    role_response = iam_client.get_role(RoleName=role_name)
+    return role_response["Role"]["Arn"]
+
+
+def _get_default_s3_bucket(region_name):
+    # create bucket if it does not exist
+    sess = boto3.Session()
+    account_id = _get_account_id()
+    region_name = sess.region_name or "us-west-2"
+    bucket_name = "{pfx}-{rn}-{aid}".format(pfx=DEFAULT_BUCKET_NAME_PREFIX, rn=region_name, aid=account_id)
+    s3 = sess.client('s3')
+    response = s3.list_buckets()
+    buckets = [b['Name'] for b in response["Buckets"]]
+    if not bucket_name in buckets:
+        eprint("Default bucket `%s` not found. Creating..." % bucket_name)
+        response = s3.create_bucket(
+            ACL='bucket-owner-full-control',
+            Bucket=bucket_name,
+            CreateBucketConfiguration={
+                'LocationConstraint': region_name, 
+            },
+        )
+        eprint(response)
+    else:
+        eprint("Default bucket `%s` already exists. Skipping creation." % bucket_name)
+    return bucket_name
+
+
 def _make_tarfile(output_filename, source_dir):
     """
     create a tar.gz from a directory.
@@ -240,25 +315,22 @@ def _upload_s3(local_model_path, bucket, prefix):
             return '{}/{}/{}'.format(s3.meta.endpoint_url, bucket, key)
 
 
-def _deploy(role, image, app_name, model_s3_path, run_id, region_name):
+def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name):
     """
     Deploy model on sagemaker.
     :param role: SageMaker execution ARN role
-    :param image: Name of the Docker image the model is being deployed into
+    :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param app_name: Name of the deployed app
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
     """
     sage_client = boto3.client('sagemaker', region_name=region_name)
-    ecr_client = boto3.client("ecr")
-    repository_conf = ecr_client.describe_repositories(
-        repositoryNames=[image])['repositories'][0]
     model_name = app_name + '-model'
     model_response = sage_client.create_model(
         ModelName=model_name,
         PrimaryContainer={
             'ContainerHostname': 'mlflow-serve-%s' % model_name,
-            'Image': repository_conf["repositoryUri"],
+            'Image': image_url,
             'ModelDataUrl': model_s3_path,
             'Environment': {},
         },

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -21,8 +21,11 @@ PREBUILT_IMAGE_URLS = {
 
 def _get_prebuilt_image_url(region):
     if region not in PREBUILT_IMAGE_URLS:
-        return None
-    return (PREBUILT_IMAGE_URLS[region] + ":{version}").format(version=mlflow.version.NEXT_VERSION)
+        raise ValueError(
+            "Prebuilt images are not available in region {region}. ".format(region=region) +
+            "Please specify a valid region or an image_url in the desired region. " +
+            "Valid regions are: {regions}".format(regions=", ".join(PREBUILT_IMAGE_URLS.keys())))
+    return (PREBUILT_IMAGE_URLS[region] + ":{version}").format(version=mlflow.version.VERSION)
 
 DEFAULT_BUCKET_NAME_PREFIX = "mlflow-sagemaker"
 
@@ -147,7 +150,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
 
 
 def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=None,
-           image=None, region_name="us-west-2"):
+           image_url=None, region_name="us-west-2"):
     """
     Deploy model on SageMaker.
     Current active AWS account needs to have correct permissions setup.
@@ -164,12 +167,8 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
                   publicly-available pre-built image.
     :param region_name: Name of the AWS region to deploy to. defaults to 
     """
-    image_url = _get_prebuilt_image_url(region)
-    if image or image_url is None:
-        ecr_client = boto3.client("ecr")
-        repository_conf = ecr_client.describe_repositories(
-            repositoryNames=[image])['repositories'][0]
-        image_url = repository_conf["repositoryUri"]
+    if not image_url:
+        image_url = _get_prebuilt_image_url(region_name)
 
     if not execution_role_arn:
         execution_role_arn = _get_assumed_role_arn()

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -22,7 +22,7 @@ def commands():
 @click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
 @click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
 @cli_args.RUN_ID
-@click.option("--image_url", "-i", default=None, help="ECR URL for the Docker image")
+@click.option("--image-url", "-i", default=None, help="ECR URL for the Docker image")
 @click.option("--region-name", "-r", default="us-west-2", help="region name")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name):
     """

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -22,27 +22,27 @@ def commands():
 @click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
 @click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
 @cli_args.RUN_ID
-@click.option("--container", "-c", default=None, help="container name")
+@click.option("--image_url", "-i", default=None, help="ECR URL for the Docker image")
 @click.option("--region-name", "-r", default="us-west-2", help="region name")
-def deploy(app_name, model_path, execution_role_arn, bucket, run_id, container, region_name):
+def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name):
     """
-    Deploy model on Sagemaker. Current active AWS account needs to have correct permissions setup.
+    Deploy model on Sagemaker as a REST API endpoint. Current active AWS account needs to have correct permissions setup.
     """
     mlflow.sagemaker.deploy(app_name=app_name, model_path=model_path,
                             execution_role_arn=execution_role_arn, bucket=bucket, run_id=run_id,
-                            image=container, region_name=region_name)
+                            image_url=image_url, region_name=region_name)
 
 
 @commands.command("run-local")
 @cli_args.MODEL_PATH
 @cli_args.RUN_ID
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")
-@click.option("--container", "-c", default=IMAGE, help="container name")
-def run_local(model_path, run_id, port, container):
+@click.option("--image", "-i", default=IMAGE, help="Docker image name")
+def run_local(model_path, run_id, port, image):
     """
     Serve model locally running in a Sagemaker-compatible Docker container.
     """
-    mlflow.sagemaker.run_local(model_path=model_path, run_id=run_id, port=port, image=container)
+    mlflow.sagemaker.run_local(model_path=model_path, run_id=run_id, port=port, image=image)
 
 
 @commands.command("build-and-push-container")

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -19,11 +19,11 @@ def commands():
 @commands.command("deploy")
 @click.option("--app-name", "-a", help="Application name.", required=True)
 @cli_args.MODEL_PATH
-@click.option("--execution-role-arn", "-e", help="SageMaker execution role", required=True)
-@click.option("--bucket", "-b", help="S3 bucket to store model artifacts", required=True)
+@click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
+@click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
 @cli_args.RUN_ID
-@click.option("--container", "-c", default="mlflow_sage", help="container name")
-@click.option("--region-name", default="us-west-2", help="region name")
+@click.option("--container", "-c", default=None, help="container name")
+@click.option("--region-name", "-r", default="us-west-2", help="region name")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, container, region_name):
     """
     Deploy model on Sagemaker. Current active AWS account needs to have correct permissions setup.

--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -66,6 +66,9 @@ def _serve():
         print("activating custom environment")
         env = conf[pyfunc.ENV]
         env_path_dst = os.path.join("/opt/mlflow/", env)
+        env_path_dst_dir = os.path.dirname(env_path_dst)
+        if not os.path.exists(env_path_dst_dir):
+            os.makedirs(env_path_dst_dir)
         # /opt/ml/ is read-only, we need to copy the env elsewhere before importing it
         shutil.copy(src=os.path.join("/opt/ml/model/", env), dst=env_path_dst)
         os.system("conda env create -n custom_env -f {}".format(env_path_dst))

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,3 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 VERSION = '0.2.1' #  NOQA
+NEXT_VERSION = '0.2.2' #  NOQA

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,3 @@
 # Copyright 2018 Databricks, Inc.
 
-VERSION = '0.2.1' #  NOQA
-NEXT_VERSION = '0.2.2' #  NOQA
+VERSION = '0.2.1'  # NOQA


### PR DESCRIPTION
* The "delete" operation is invoked on an application name. All resources created by calling `deploy(app_name)` are deleted by `delete(app_name)`. 

* This does not handle model archiving because MLFlow does not support deployment from an archived SageMaker model